### PR TITLE
feat: add switcher schedule view mode

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12050,6 +12050,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "mobile-device-detect": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/mobile-device-detect/-/mobile-device-detect-0.4.3.tgz",
+      "integrity": "sha512-SN9EBE9SoJgkb83kuUVoIp3R9OGYE5dYEnLEz2oLooh0DzgtQ72BJmpNGqrgFvmfE4iLR2CaVJ3RjUcStheVZg=="
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "chart.js": "^2.9.3",
     "csvtojson": "~2.0.10",
     "lodash": "~4.17.19",
+    "mobile-device-detect": "^0.4.3",
     "moment": "~2.24.0",
     "moment-timezone": "~0.5.28",
     "next": "^9.5.4",

--- a/client/src/components/Schedule/CalendarView.tsx
+++ b/client/src/components/Schedule/CalendarView.tsx
@@ -1,0 +1,17 @@
+import { CourseEvent } from 'services/course';
+
+type Props = {
+  data: CourseEvent[];
+  timeZone: string;
+};
+
+export function CalendarView({ data, timeZone }: Props) {
+  return (
+    <div>
+      <h2>Calendar</h2>
+      Data length = {data.length}. Timezone = {timeZone}
+    </div>
+  );
+}
+
+export default CalendarView;

--- a/client/src/components/Schedule/ListView.tsx
+++ b/client/src/components/Schedule/ListView.tsx
@@ -1,0 +1,17 @@
+import { CourseEvent } from 'services/course';
+
+type Props = {
+  data: CourseEvent[];
+  timeZone: string;
+};
+
+export function ListView({ data, timeZone }: Props) {
+  return (
+    <div>
+      <h2>List</h2>
+      Data length = {data.length}. Timezone = {timeZone}
+    </div>
+  );
+}
+
+export default ListView;

--- a/client/src/components/Schedule/index.ts
+++ b/client/src/components/Schedule/index.ts
@@ -1,0 +1,3 @@
+export { TableView } from './TableView';
+export { CalendarView } from './CalendarView';
+export { ListView } from './ListView';

--- a/client/src/components/Schedule/model.ts
+++ b/client/src/components/Schedule/model.ts
@@ -45,3 +45,5 @@ export const EventTypeToName: Record<string, string> = {
   'codewars:stage1': 'codewars',
   'codewars:stage2': 'codewars',
 };
+
+export type ViewMode = 'calendar' | 'table' | 'list';

--- a/client/src/components/Schedule/model.ts
+++ b/client/src/components/Schedule/model.ts
@@ -46,10 +46,8 @@ export const EventTypeToName: Record<string, string> = {
   'codewars:stage2': 'codewars',
 };
 
-export type ViewModeType = 'Calendar' | 'Table' | 'List';
-
 export enum ViewMode {
-  table = 'Table',
-  list = 'List',
-  calendar = 'Calendar',
+  TABLE = 'TABLE',
+  LIST = 'LIST',
+  CALENDAR = 'CALENDAR',
 }

--- a/client/src/components/Schedule/model.ts
+++ b/client/src/components/Schedule/model.ts
@@ -46,4 +46,10 @@ export const EventTypeToName: Record<string, string> = {
   'codewars:stage2': 'codewars',
 };
 
-export type ViewMode = 'calendar' | 'table' | 'list';
+export type ViewModeType = 'Calendar' | 'Table' | 'List';
+
+export enum ViewMode {
+  table = 'Table',
+  list = 'List',
+  calendar = 'Calendar',
+}

--- a/client/src/pages/course/schedule.tsx
+++ b/client/src/pages/course/schedule.tsx
@@ -9,6 +9,7 @@ import { TIMEZONES } from '../../configs/timezones';
 import { useAsync, useLocalStorage } from 'react-use';
 import { useLoading } from 'components/useLoading';
 import { isMobileOnly } from 'mobile-device-detect';
+import { ViewMode } from 'components/Schedule/model';
 
 const { Option } = Select;
 const LOCAL_VIEW_MODE = 'scheduleViewMode';
@@ -39,31 +40,23 @@ export function SchedulePage(props: CoursePageProps) {
     [courseService],
   );
 
-  let schedule;
+  const mapScheduleViewToComponent = {
+    table: TableView,
+    list: ListView,
+    calendar: CalendarView,
+  };
 
-  switch (scheduleViewMode) {
-    case 'Table':
-      schedule = <TableView data={data} timeZone={timeZone} />;
-      break;
-    case 'List':
-      schedule = <ListView data={data} timeZone={timeZone} />;
-      break;
-    case 'Calendar':
-      schedule = <CalendarView data={data} timeZone={timeZone} />;
-      break;
-    default:
-      schedule = <TableView data={data} timeZone={timeZone} />;
-      break;
-  }
+  const viewMode = (scheduleViewMode || 'table') as ViewMode;
+  const ScheduleView = mapScheduleViewToComponent[viewMode];
 
   return (
     <PageLayout loading={loading} title="Schedule" githubId={props.session.githubId}>
       <Row justify="start" gutter={[16, 16]}>
         <Col>
           <Select style={{ width: 100 }} defaultValue={scheduleViewMode} onChange={setScheduleViewMode}>
-            <Option value="Table">Table</Option>
-            <Option value="List">List</Option>
-            <Option value="Calendar">Calendar</Option>
+            <Option value="table">Table</Option>
+            <Option value="list">List</Option>
+            <Option value="calendar">Calendar</Option>
           </Select>
         </Col>
         <Col>
@@ -81,7 +74,7 @@ export function SchedulePage(props: CoursePageProps) {
           </Select>
         </Col>
       </Row>
-      {schedule}
+      <ScheduleView data={data} timeZone={timeZone} />
     </PageLayout>
   );
 }
@@ -119,10 +112,10 @@ const getDefaultViewMode = (): string => {
   }
 
   if (isMobileOnly) {
-    return 'List';
+    return 'list';
   }
 
-  return 'Table';
+  return 'table';
 };
 
 export default withCourseData(withSession(SchedulePage));

--- a/client/src/pages/course/schedule.tsx
+++ b/client/src/pages/course/schedule.tsx
@@ -1,13 +1,17 @@
-import { Row, Select } from 'antd';
+import { Col, Row, Select } from 'antd';
 import { withSession, PageLayout } from 'components';
-import TableView from 'components/Schedule/TableView';
+import { TableView, CalendarView, ListView } from 'components/Schedule';
 import withCourseData from 'components/withCourseData';
 import { useState, useMemo } from 'react';
 import { CourseEvent, CourseService, CourseTaskDetails } from 'services/course';
 import { CoursePageProps } from 'services/models';
 import { TIMEZONES } from '../../configs/timezones';
-import { useAsync } from 'react-use';
+import { useAsync, useLocalStorage } from 'react-use';
 import { useLoading } from 'components/useLoading';
+import { isMobileOnly } from 'mobile-device-detect';
+
+const { Option } = Select;
+const LOCAL_VIEW_MODE = 'scheduleViewMode';
 
 const TaskTypes = {
   deadline: 'deadline',
@@ -20,6 +24,7 @@ export function SchedulePage(props: CoursePageProps) {
   const [loading, withLoading] = useLoading(false);
   const [data, setData] = useState<CourseEvent[]>([]);
   const [timeZone, setTimeZone] = useState(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  const [scheduleViewMode, setScheduleViewMode] = useLocalStorage<string>(LOCAL_VIEW_MODE, getDefaultViewMode());
   const courseService = useMemo(() => new CourseService(props.course.id), [props.course.id]);
 
   useAsync(
@@ -34,23 +39,49 @@ export function SchedulePage(props: CoursePageProps) {
     [courseService],
   );
 
+  let schedule;
+
+  switch (scheduleViewMode) {
+    case 'Table':
+      schedule = <TableView data={data} timeZone={timeZone} />;
+      break;
+    case 'List':
+      schedule = <ListView data={data} timeZone={timeZone} />;
+      break;
+    case 'Calendar':
+      schedule = <CalendarView data={data} timeZone={timeZone} />;
+      break;
+    default:
+      schedule = <TableView data={data} timeZone={timeZone} />;
+      break;
+  }
+
   return (
     <PageLayout loading={loading} title="Schedule" githubId={props.session.githubId}>
-      <Row justify="space-between" style={{ marginBottom: 16 }}>
-        <Select
-          style={{ width: 200 }}
-          placeholder="Please select a timezone"
-          defaultValue={timeZone}
-          onChange={setTimeZone}
-        >
-          {TIMEZONES.map(tz => (
-            <Select.Option key={tz} value={tz}>
-              {tz}
-            </Select.Option>
-          ))}
-        </Select>
+      <Row justify="start" gutter={[16, 16]}>
+        <Col>
+          <Select style={{ width: 100 }} defaultValue={scheduleViewMode} onChange={setScheduleViewMode}>
+            <Option value="Table">Table</Option>
+            <Option value="List">List</Option>
+            <Option value="Calendar">Calendar</Option>
+          </Select>
+        </Col>
+        <Col>
+          <Select
+            style={{ width: 200 }}
+            placeholder="Please select a timezone"
+            defaultValue={timeZone}
+            onChange={setTimeZone}
+          >
+            {TIMEZONES.map(tz => (
+              <Option key={tz} value={tz}>
+                {tz}
+              </Option>
+            ))}
+          </Select>
+        </Col>
       </Row>
-      <TableView data={data} timeZone={timeZone} />
+      {schedule}
     </PageLayout>
   );
 }
@@ -78,6 +109,20 @@ const createCourseEventFromTask = (task: CourseTaskDetails, type: string): Cours
       githubId: task.taskOwner ? task.taskOwner.githubId : '',
     },
   } as CourseEvent;
+};
+
+const getDefaultViewMode = (): string => {
+  const localView = localStorage.getItem(LOCAL_VIEW_MODE);
+
+  if (localView) {
+    return localView;
+  }
+
+  if (isMobileOnly) {
+    return 'List';
+  }
+
+  return 'Table';
 };
 
 export default withCourseData(withSession(SchedulePage));

--- a/client/src/pages/course/schedule.tsx
+++ b/client/src/pages/course/schedule.tsx
@@ -9,7 +9,7 @@ import { TIMEZONES } from '../../configs/timezones';
 import { useAsync, useLocalStorage } from 'react-use';
 import { useLoading } from 'components/useLoading';
 import { isMobileOnly } from 'mobile-device-detect';
-import { ViewMode, ViewModeType } from 'components/Schedule/model';
+import { ViewMode } from 'components/Schedule/model';
 
 const { Option } = Select;
 const LOCAL_VIEW_MODE = 'scheduleViewMode';
@@ -41,12 +41,12 @@ export function SchedulePage(props: CoursePageProps) {
   );
 
   const mapScheduleViewToComponent = {
-    [ViewMode.table]: TableView,
-    [ViewMode.list]: ListView,
-    [ViewMode.calendar]: CalendarView,
+    [ViewMode.TABLE]: TableView,
+    [ViewMode.LIST]: ListView,
+    [ViewMode.CALENDAR]: CalendarView,
   };
 
-  const viewMode = scheduleViewMode as ViewModeType;
+  const viewMode = scheduleViewMode as ViewMode;
   const ScheduleView = mapScheduleViewToComponent[viewMode] || TableView;
 
   return (
@@ -54,9 +54,9 @@ export function SchedulePage(props: CoursePageProps) {
       <Row justify="start" gutter={[16, 16]}>
         <Col>
           <Select style={{ width: 100 }} defaultValue={scheduleViewMode} onChange={setScheduleViewMode}>
-            <Option value={ViewMode.table}>{ViewMode.table}</Option>
-            <Option value={ViewMode.list}>{ViewMode.list}</Option>
-            <Option value={ViewMode.calendar}>{ViewMode.calendar}</Option>
+            <Option value={ViewMode.TABLE}>Table</Option>
+            <Option value={ViewMode.LIST}>List</Option>
+            <Option value={ViewMode.CALENDAR}>Calendar</Option>
           </Select>
         </Col>
         <Col>
@@ -112,10 +112,10 @@ const getDefaultViewMode = () => {
   }
 
   if (isMobileOnly) {
-    return ViewMode.list;
+    return ViewMode.LIST;
   }
 
-  return ViewMode.table;
+  return ViewMode.TABLE;
 };
 
 export default withCourseData(withSession(SchedulePage));

--- a/client/src/pages/course/schedule.tsx
+++ b/client/src/pages/course/schedule.tsx
@@ -9,7 +9,7 @@ import { TIMEZONES } from '../../configs/timezones';
 import { useAsync, useLocalStorage } from 'react-use';
 import { useLoading } from 'components/useLoading';
 import { isMobileOnly } from 'mobile-device-detect';
-import { ViewMode } from 'components/Schedule/model';
+import { ViewMode, ViewModeType } from 'components/Schedule/model';
 
 const { Option } = Select;
 const LOCAL_VIEW_MODE = 'scheduleViewMode';
@@ -41,22 +41,22 @@ export function SchedulePage(props: CoursePageProps) {
   );
 
   const mapScheduleViewToComponent = {
-    table: TableView,
-    list: ListView,
-    calendar: CalendarView,
+    [ViewMode.table]: TableView,
+    [ViewMode.list]: ListView,
+    [ViewMode.calendar]: CalendarView,
   };
 
-  const viewMode = (scheduleViewMode || 'table') as ViewMode;
-  const ScheduleView = mapScheduleViewToComponent[viewMode];
+  const viewMode = scheduleViewMode as ViewModeType;
+  const ScheduleView = mapScheduleViewToComponent[viewMode] || TableView;
 
   return (
     <PageLayout loading={loading} title="Schedule" githubId={props.session.githubId}>
       <Row justify="start" gutter={[16, 16]}>
         <Col>
           <Select style={{ width: 100 }} defaultValue={scheduleViewMode} onChange={setScheduleViewMode}>
-            <Option value="table">Table</Option>
-            <Option value="list">List</Option>
-            <Option value="calendar">Calendar</Option>
+            <Option value={ViewMode.table}>{ViewMode.table}</Option>
+            <Option value={ViewMode.list}>{ViewMode.list}</Option>
+            <Option value={ViewMode.calendar}>{ViewMode.calendar}</Option>
           </Select>
         </Col>
         <Col>
@@ -104,7 +104,7 @@ const createCourseEventFromTask = (task: CourseTaskDetails, type: string): Cours
   } as CourseEvent;
 };
 
-const getDefaultViewMode = (): string => {
+const getDefaultViewMode = () => {
   const localView = localStorage.getItem(LOCAL_VIEW_MODE);
 
   if (localView) {
@@ -112,10 +112,10 @@ const getDefaultViewMode = (): string => {
   }
 
   if (isMobileOnly) {
-    return 'list';
+    return ViewMode.list;
   }
 
-  return 'table';
+  return ViewMode.table;
 };
 
 export default withCourseData(withSession(SchedulePage));


### PR DESCRIPTION
Add switcher schedule view mode. 
Default mode (clear local storage): for mobile only - **List**, for others - **Table**.

![image](https://user-images.githubusercontent.com/60464016/99569859-35639b00-29e2-11eb-8184-d4b69780a1a0.png)
